### PR TITLE
Htree to dico

### DIFF
--- a/source/files/dico/dictionnary.c
+++ b/source/files/dico/dictionnary.c
@@ -10,6 +10,15 @@
 #include "../SLL/Element.h"
 
 
+
+Dico* htreetodico(Tree* huff)
+{
+    char buffer[100];
+    Dico* ret = all_left_dico(huff, buffer, 0, 100);
+    balance_BST_all_left(&ret);
+    return ret;
+}
+
 char* get_value(Dico* dictionary, char key)
 {
     if(!dictionary)

--- a/source/files/dico/dictionnary.c
+++ b/source/files/dico/dictionnary.c
@@ -11,6 +11,43 @@
 
 
 
+int lenght(Dico* d)
+{
+    if(d != NULL)
+    {
+        return 1 + lenght(d->left);
+    }
+    return 0;
+}
+Dico* mid_of(Dico* d)
+{
+    int len = lenght(d);
+
+    Dico* ret = d;
+    for(int i = 0; i<len/2 - 1; i++)
+    {
+        ret = ret->left;
+    }
+    Dico* buffer = ret;
+    ret = ret->left;
+    buffer->left = NULL;
+
+    return ret;
+}
+void balance_BST_all_left(Dico** tree)
+{
+    if(tree == NULL){return;}
+
+    if(*tree != NULL && (*tree)->left != NULL)
+    {
+        Dico* buffer = *tree;
+        *tree = mid_of(buffer);
+        (*tree)->right = buffer;
+        balance_BST_all_left(&(*tree)->left);
+        balance_BST_all_left(&(*tree)->right);
+    }
+}
+
 Dico* htreetodico(Tree* huff)
 {
     char buffer[100];

--- a/source/files/dico/dictionnary.c
+++ b/source/files/dico/dictionnary.c
@@ -10,6 +10,71 @@
 #include "../SLL/Element.h"
 
 
+Dico* merge(Dico* a, Dico* b)
+{
+    if(a == NULL)
+    {
+        if(b == NULL)
+        {
+            return NULL;
+        }
+        return b;
+    }
+    if(b == NULL)
+    {
+        return a;
+    }
+
+    Dico** scan = &a;
+    while(*scan != NULL)
+    {
+        if(b != NULL && b->data < (*scan)->data)
+        {
+            Dico* temp = b;
+            b = b->left;
+            temp->left = *scan;
+            *scan = temp;
+        }
+        scan = &(*scan)->left;
+    }
+    if(b != NULL)
+    {
+        *scan = b;
+    }
+    return a;
+}
+
+Dico* all_left_dico(Tree* huff, char* buffer, int lsize, int psize)
+{
+    if(huff == NULL){return NULL;}
+    if(huff->data != 0)
+    {
+        Dico* ret = (Dico*)malloc(sizeof(Dico));
+        ret->key = huff->data;
+        ret->value = copy(buffer, lsize);
+        ret->left = NULL;
+        ret->right = NULL;
+
+        return ret;
+    }
+
+    int fr = 0;
+    if(lsize + 1 > psize)
+    {
+        psize += 100;
+        buffer = (char*)malloc(psize*sizeof(char));
+        fr = 1;
+    }
+
+    buffer[lsize] = '0';
+    Dico* zero = all_left_dico(huff->left, buffer, lsize+1, psize);
+    buffer[lsize] = '1';
+    Dico* one = all_left_dico(huff->right, buffer, lsize+1, psize);
+
+    if(fr){free(buffer);}
+
+    return merge(zero, one);
+}
 
 int lenght(Dico* d)
 {

--- a/source/files/dico/dictionnary.h
+++ b/source/files/dico/dictionnary.h
@@ -18,6 +18,7 @@ typedef struct _dictionary
     struct _dictionary *left;
 }Dico;
 
+Dico* htreetodico(Tree* huff);
 char* get_value(Dico* dictionary, char key);
 Dico* slltodico(Element* node);
 void d_free(Dico* dictionary);


### PR DESCRIPTION
## Change log

### Function Creation in source/files/dico/dictionnary.c

**Dico\* htreetodico(Tree\* huff)**  (log in the prototypes)
A function which use its sub fuction to return an AVL dictionnary

**void balance_BST_all_left(Dico\*\* tree)**
Ballance a Tree that is comparable with a sorted SLL where next is left leave

**Dico\* mid_of(Dico\* d)**
return the midlle of a dictionnary by using lenght function

**int lenght(Dico\* d)**
return the lenght of a dictionnary

**Dico\* all_left_dico(Tree\* huff, char\* buffer, int lsize, int psize)**
give recursively from a huffman tree a sorted "all-left" dictionnary. It uses a char\* buffer

**Dico\* merge(Dico\* a, Dico\* b)**
merge two sorted all-left dictionnaries.