### PR TITLE
Compression.c memory leak fix

### DIFF
--- a/source/files/compression/compression.c
+++ b/source/files/compression/compression.c
@@ -10,6 +10,7 @@ int decompression(char* target, char *tree, char *outputPath)
 {
     FILE* treeFile = fopen(tree, "r");
     Tree* arbre = read_tree(treeFile);
+    fclose(treeFile);
 
     FILE* binaries = NULL;
     binaries = fopen(target, "r");
@@ -46,6 +47,8 @@ int decompression(char* target, char *tree, char *outputPath)
 
     fclose(binaries);
     fclose(output);
+
+    t_free(arbre);
     return 0;
 }
 
@@ -89,7 +92,7 @@ int compression(char *target)
     Element* HS = BT_to_UT(occurrences);
     SLL_to_HT(&HS);
     Tree* HT = HS->node;
-    Dico* dictionary = htreetodico(HT, occurrences);
+    Dico* dictionary = htreetodico(HT, occurrences); // it free occurrences
 
     // temporary
     //Tree* h_tree = sort_SLL_to_BT(list);

--- a/source/files/dico/dictionnary.c
+++ b/source/files/dico/dictionnary.c
@@ -15,6 +15,7 @@ Dico* htreetodico(Tree* huff, Tree* ascii)
         (tree)->value = get_bin(ascii->data, huff, 0);
         (tree)->left = htreetodico(huff, ascii->left);
         (tree)->right = htreetodico(huff, ascii->right);
+        free(ascii);
         return tree;
     }
     return NULL;


### PR DESCRIPTION
- closing the tree file in decompression
- free "arbre" in decompression
- free occurrences inside htreetodico function in compression

I didn't find any more memory leaks in the other files